### PR TITLE
Add Waffle Badge to repository's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Stories in Ready](https://badge.waffle.io/ashumz/trends-online.png?label=ready&title=Ready)](https://waffle.io/ashumz/trends-online)
-[![Stories in Ready](https://badge.waffle.io/CodeForBoulder/trends-online.png?label=ready&title=Ready)](https://waffle.io/CodeForBoulder/trends-online)
+[![Stories in Ready](https://badge.waffle.io/CodeForBoulder/trends-online.png?label=ready&title=Issues Ready To Be Worked On)](https://waffle.io/CodeForBoulder/trends-online)
 # trends-online
 Making the Community Foundation's TRENDS report more accessible. See the original [here](http://www.commfound.org/trendsmagazine).


### PR DESCRIPTION
So it's quick and easy to access the Waffle board -- any team member or anyone interested in the project can click on the badge to see the board and what's in progress, what's up next, and what has been completed in the last week. 